### PR TITLE
ReadMe: Add command to make Git use long paths on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Setup line endings preferences:
     git config --global core.autocrlf true
     git config --global core.safecrlf true
 
+On Windows, you must explicitly tell Git to use long paths so you won't run into issues with files in deeply nested directories:
+
+    git config --global core.longpaths true
+
 The merge is working pretty well on small repositories (with move and rename of files). But it's not working on large repositories as the detection of file renaming is O(n²), so we need to update some threshold (more explanations are available in this post : http://blogs.atlassian.com/2011/10/confluence_git_rename_merge_oh_my/) :
 
     git config --global merge.renameLimit 10000


### PR DESCRIPTION
Git lives in the 90s by default, it seems... I just ran into this issue, it seems like others could benefit from it as well.