### PR TITLE
Align line length configuration to documentation

### DIFF
--- a/eclipse/sonar-formatter.xml
+++ b/eclipse/sonar-formatter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<profiles version="23">
-<profile kind="CodeFormatterProfile" name="SonarQube" version="23">
+<profiles version="24">
+<profile kind="CodeFormatterProfile" name="SonarQube" version="24">
 <setting id="org.eclipse.jdt.core.formatter.align_arrows_in_switch_on_columns" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="99"/>
@@ -107,7 +107,7 @@
 <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_between_different_tags" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.javadoc_do_not_separate_block_tags" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="140"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="180"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>

--- a/intellij/codestyle_sonar_developer_toolset.xml
+++ b/intellij/codestyle_sonar_developer_toolset.xml
@@ -1,5 +1,5 @@
-<code_scheme name="sonar-developer-toolset" version="173">
-  <option name="RIGHT_MARGIN" value="140" />
+<code_scheme name="sonar-developer-toolset" version="174">
+  <option name="RIGHT_MARGIN" value="180" />
   <JavaCodeStyleSettings>
     <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
     <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
@@ -41,6 +41,7 @@
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="kotlin">
+    <option name="RIGHT_MARGIN" value="140" />
     <option name="CALL_PARAMETERS_WRAP" value="5" />
     <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
     <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />


### PR DESCRIPTION
* Set default line length to 180 characters
* Override Kotlin line length to 140 characters
* Increment configuration files version