### PR TITLE
NO-JIRA Add a fallback for Prettier instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ We use a tool called **Prettier**. In order to ensure it functions correctly, in
 Once installed set the files as such:
 ![Intellij javascript prettier](intellij/intellij-javascript-prettier.png)
 
+The Prettier plugin requires IntelliJ ultimate, but it's possible to use it without the plugin, e.g. [here](https://github.com/SonarSource/sonar-developer-toolset/pull/32#issuecomment-1514574604).
+
 Then to make sure prettier is run correctly, modify the on save actions:
 ![Intellij javascript onsave](intellij/intellij-javscript-actionsonsave.png)
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ We use a tool called **Prettier**. In order to ensure it functions correctly, in
 Once installed set the files as such:
 ![Intellij javascript prettier](intellij/intellij-javascript-prettier.png)
 
-The Prettier plugin requires IntelliJ ultimate, but it's possible to use it without the plugin, e.g. [here](https://github.com/SonarSource/sonar-developer-toolset/pull/32#issuecomment-1514574604).
+The Prettier plugin requires IntelliJ Ultimate, but it's possible to use it without the plugin, e.g. [like this](https://github.com/SonarSource/sonar-developer-toolset/pull/32#issuecomment-1514574604).
 
 Then to make sure prettier is run correctly, modify the on save actions:
 ![Intellij javascript onsave](intellij/intellij-javscript-actionsonsave.png)


### PR DESCRIPTION
From the wiki it sounds like IntelliJ Ultimate is not commonly used, so this provides a Prettier installation fallback.