### PR TITLE
Enable `@formatter:on/off` tags.

### DIFF
--- a/eclipse/sonar-formatter.xml
+++ b/eclipse/sonar-formatter.xml
@@ -385,7 +385,7 @@
 <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
 <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="2"/>
 <setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.wrap_before_additive_operator" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.wrap_before_assertion_message_operator" value="true"/>


### PR DESCRIPTION
When placing the tag `@formatter:off` or `@formatter:on` in a comment, it did not actually deactivate/activate the formatter for the remaining code.

Example:
``````java
// This is a Java comment that has some internal formatting that should not
// be affected by the formatter:
//
// @formatter:off
// ```java
// class SomeCodeSnippet {
//   void method() {
//     // ...
//   }
// }
// ```
// @formatter:on
//
// Without deactivating the formatter above, all leading whitespace and
// thus intendation would be removed in the code snippet above.
``````

**This PR adjust the eclipse formatter settings to enable these tags.**